### PR TITLE
🔒 Fix CVE-2022-1304: Vulnerability in e2fsprogs and related packages

### DIFF
--- a/webapp/Dockerfile
+++ b/webapp/Dockerfile
@@ -30,11 +30,11 @@ ENV NODE_ENV=production
 RUN apt-get update && \
     apt-get upgrade -y && \
     apt-get install -y --no-install-recommends \
-    e2fsprogs \
-    libcom-err2 \
-    libext2fs2 \
-    libss2 \
-    logsave && \
+    e2fsprogs=1.46.2-2+deb11u1 \
+    libcom-err2=1.46.2-2+deb11u1 \
+    libext2fs2=1.46.2-2+deb11u1 \
+    libss2=1.46.2-2+deb11u1 \
+    logsave=1.46.2-2+deb11u1 && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
🐳 The Docker image contains a security vulnerability (CVE-2022-1304) affecting several installed packages:
- e2fsprogs
- libcom-err2
- libext2fs2
- libss2
- logsave

This vulnerability allows out-of-bounds read/write, potentially leading to segmentation faults or arbitrary code execution via a specially crafted filesystem.

### 💂 Tasks:
- [x] Update the affected packages to a secure version (1.46.2-2+deb11u1).
- [x] Test and verify the image after package updates.
- [x] Run Trivy scan again to confirm that the vulnerability is resolved.