### PR TITLE
Add Middleware Template and Configuration

### DIFF
--- a/helm/templates/ingressroute.yaml
+++ b/helm/templates/ingressroute.yaml
@@ -23,6 +23,12 @@ spec:
           scheme: {{ .scheme }}
           {{- end }}
         {{- end }}
+      {{- with .middlewares }}
+      middlewares:
+        {{- range .middlewares }}
+        - name: {{ . }}
+        {{- end }}
+      {{- end }}
     {{- end }}
   {{- with .Values.ingressRoute.tls }}
   tls:

--- a/helm/templates/middleware.yaml
+++ b/helm/templates/middleware.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.middlewares }}
+{{- range .Values.middlewares }}
+---
+apiVersion: traefik.io/v1alpha1
+kind: Middleware
+metadata:
+  name: {{ .name }}
+  labels:
+    {{- include "k8s-auto-loadbalancer.labels" $ | nindent 4 }}
+spec:
+  {{- toYaml .spec | nindent 2 }}
+{{- end }}
+{{- end }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -101,6 +101,10 @@ ingressRoute:
       services:
         - name: k8s-auto-loadbalancer
           port: 80
+      middlewares:
+        - health-check
+        - strip-prefix
+        - rate-limit
   tls:
     certResolver: cloudflare
 

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -104,6 +104,23 @@ ingressRoute:
   tls:
     certResolver: cloudflare
 
+middlewares:
+  - name: health-check
+    spec:
+      headers:
+        customRequestHeaders:
+          X-Forwarded-Proto: https
+  - name: strip-prefix
+    spec:
+      stripPrefix:
+        prefixes:
+          - /api
+  - name: rate-limit
+    spec:
+      rateLimit:
+        average: 100
+        burst: 50
+
 podDisruptionBudget:
   enabled: true
   minAvailable: 1


### PR DESCRIPTION
## Description

This PR adds a new middleware template and updates the related configurations to improve the flexibility and manageability of our Kubernetes Automated Load Balancer project.

## Changes

1. Add new file: `helm/templates/middleware.yaml`
```yaml
{{- if .Values.middlewares }}
{{- range .Values.middlewares }}
---
apiVersion: traefik.io/v1alpha1
kind: Middleware
metadata:
  name: {{ .name }}
  labels:
    {{- include "k8s-auto-loadbalancer.labels" $ | nindent 4 }}
spec:
  {{- toYaml .spec | nindent 2 }}
{{- end }}
{{- end }}
```

2. Update `helm/values.yaml`:
Add the following section:
```yaml
middlewares:
  - name: health-check
    spec:
      headers:
        customRequestHeaders:
          X-Forwarded-Proto: https
  - name: strip-prefix
    spec:
      stripPrefix:
        prefixes:
          - /api
  - name: rate-limit
    spec:
      rateLimit:
        average: 100
        burst: 50
```

3. Update `helm/templates/ingressroute.yaml`:
Modify the routes section to include middlewares:
```yaml
spec:
  entryPoints:
    {{- range .Values.ingressRoute.entryPoints }}
    - {{ . }}
    {{- end }}
  routes:
    {{- range .Values.ingressRoute.routes }}
    - match: {{ .match }}
      kind: {{ .kind }}
      priority: {{ .priority }}
      services:
        {{- range .services }}
        - name: {{ .name }}
          port: {{ .port }}
          {{- if .scheme }}
          scheme: {{ .scheme }}
          {{- end }}
        {{- end }}
      {{- with .middlewares }}
      middlewares:
        {{- range .middlewares }}
        - name: {{ . }}
        {{- end }}
      {{- end }}
    {{- end }}
  {{- with .Values.ingressRoute.tls }}
  tls:
    certResolver: {{ .certResolver }}
  {{- end }}
```

4. Update `helm/values.yaml`:
Modify the ingressRoute section to include middlewares:
```yaml
ingressRoute:
  enabled: true
  name: k8s-auto-loadbalancer
  entryPoints:
    - websecure
  routes:
    - match: Host(`pungrumpy.xyz`)
      kind: Rule
      priority: 10
      services:
        - name: k8s-auto-loadbalancer
          port: 80
      middlewares:
        - health-check
        - strip-prefix
        - rate-limit
  tls:
    certResolver: cloudflare
```

## Testing

- [ ] 🚀 Deploy the updated Helm chart to a staging environment
- [ ] ✅ Verify that the middlewares are correctly created and applied
- [ ] 🔍 Test the health check and rate limiting functionality

## Additional Notes

🔧 This change improves our ability to manage and configure middlewares in a more flexible and maintainable way.